### PR TITLE
Set ignore_empty_list for curator to avoid crash. Fixes #7

### DIFF
--- a/templates/curator-configmap.yaml
+++ b/templates/curator-configmap.yaml
@@ -22,6 +22,7 @@ data:
         action: delete_indices
         description: "Clean up ES by deleting old indices"
         options:
+          ignore_empty_list: True
           timeout_override:
           continue_if_exception: False
           disable_action: False


### PR DESCRIPTION
When there are no indicies to delete, the default configuration would make the curator exit uncleanly. This avoids that scenario.