### PR TITLE
initContainer for plugin installs, newer ES version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.0.0
+version: 2.0.0
 description: Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:

--- a/templates/client-deployment.yaml
+++ b/templates/client-deployment.yaml
@@ -25,6 +25,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      securityContext:
+        fsGroup: 1000
       {{- if eq .Values.client.antiAffinity "hard" }}
       affinity:
         podAntiAffinity:
@@ -47,12 +49,7 @@ spec:
                   role: client
       {{- end }}
       initContainers:
-      - name: init-sysctl
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
-        securityContext:
-          privileged: true
+{{ include "init-containers" .Values.common | indent 6}}
       containers:
       - name: elasticsearch
         securityContext:
@@ -113,15 +110,29 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 20
         volumeMounts:
-        - mountPath: /data
+        - mountPath: /usr/share/elasticsearch/config/
+          name: configdir
+        - mountPath: /usr/share/elasticsearch/plugins/
+          name: plugindir
+        - mountPath: /storage/
           name: storage
-        - mountPath: /elasticsearch/config/elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/jvm.settings
+          name: config
+          subPath: jvm.settings
+        - mountPath: /usr/share/elasticsearch/config/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
       volumes:
+        - name: configdir
+          emptyDir: {}
+        - name: plugindir
+          emptyDir: {}
         - configMap:
             name: {{ template "fullname" . }}-config
           name: config
         - emptyDir:
             medium: ""
-          name: "storage"
+          name: storage

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -8,37 +8,64 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
+  jvm.options: |-
+    ## GC configuration
+    -XX:+UseConcMarkSweepGC
+    -XX:CMSInitiatingOccupancyFraction=75
+    -XX:+UseCMSInitiatingOccupancyOnly
+    -XX:+AlwaysPreTouch
+    -server
+    -Xss1m
+    -Djava.awt.headless=true
+    -Dfile.encoding=UTF-8
+    -Djna.nosys=true
+    -XX:-OmitStackTraceInFastThrow
+    -Dio.netty.noUnsafe=true
+    -Dio.netty.noKeySetOptimization=true
+    -Dio.netty.recycler.maxCapacityPerThread=0
+    -Dlog4j.shutdownHookEnabled=false
+    -Dlog4j2.disable.jmx=true
+
+  log4j2.properties: |-
+    status = error
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+
   elasticsearch.yml: |-
     cluster:
-      name: ${CLUSTER_NAME}
+      name: ${CLUSTER_NAME:elasticsearch}
 
     node:
-      master: ${NODE_MASTER}
-      data: ${NODE_DATA}
+      master: ${NODE_MASTER:true}
+      data: ${NODE_DATA:true}
       name: ${NODE_NAME}
-      ingest: ${NODE_INGEST}
-      max_local_storage_nodes: ${MAX_LOCAL_STORAGE_NODES}
+      ingest: ${NODE_INGEST:true}
+      max_local_storage_nodes: ${MAX_LOCAL_STORAGE_NODES:1}
 
-    network.host: ${NETWORK_HOST}
+    network.host: ${NETWORK_HOST:_local_}
 
     path:
-      data: /data/data
-      logs: /data/log
+      data: /storage/data
+      logs: /storage/logs
 
     bootstrap:
       memory_lock: ${MEMORY_LOCK:false}
 
     http:
-      enabled: ${HTTP_ENABLE}
+      enabled: ${HTTP_ENABLE:true}
       compression: true
       cors:
-        enabled: ${HTTP_CORS_ENABLE}
-        allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
+        enabled: ${HTTP_CORS_ENABLE:false}
+        allow-origin: ${HTTP_CORS_ALLOW_ORIGIN:"*"}
 
     discovery:
       zen:
-        ping.unicast.hosts: ${DISCOVERY_SERVICE}
-        minimum_master_nodes: ${NUMBER_OF_MASTERS}
+        ping.unicast.hosts: ${DISCOVERY_SERVICE:}
+        minimum_master_nodes: ${NUMBER_OF_MASTERS:1}
 
     # see https://github.com/elastic/elasticsearch-definitive-guide/pull/679
     processors: ${PROCESSORS:}

--- a/templates/data-statefulset.yaml
+++ b/templates/data-statefulset.yaml
@@ -27,6 +27,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      securityContext:
+        fsGroup: 1000
       {{- if eq .Values.data.antiAffinity "hard" }}
       affinity:
         podAntiAffinity:
@@ -49,12 +51,7 @@ spec:
                   role: data
       {{- end }}
       initContainers:
-      - name: init-sysctl
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
-        securityContext:
-          privileged: true
+{{ include "init-containers" .Values.common | indent 6 }}
       containers:
       - name: elasticsearch
         image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
@@ -121,12 +118,26 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
         volumeMounts:
-        - mountPath: /data
+        - mountPath: /usr/share/elasticsearch/config/
+          name: configdir
+        - mountPath: /usr/share/elasticsearch/plugins/
+          name: plugindir
+        - mountPath: /storage/
           name: storage
-        - mountPath: /elasticsearch/config/elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/jvm.settings
+          name: config
+          subPath: jvm.settings
+        - mountPath: /usr/share/elasticsearch/config/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
       volumes:
+        - name: configdir
+          emptyDir: {}
+        - name: plugindir
+          emptyDir: {}
         - configMap:
             name: {{ template "fullname" . }}-config
           name: config

--- a/templates/master-statefulset.yaml
+++ b/templates/master-statefulset.yaml
@@ -27,6 +27,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      securityContext:
+        fsGroup: 1000
       {{- if eq .Values.master.antiAffinity "hard" }}
       affinity:
         podAntiAffinity:
@@ -49,12 +51,7 @@ spec:
                   role: master
       {{- end }}
       initContainers:
-      - name: init-sysctl
-        image: busybox
-        imagePullPolicy: IfNotPresent
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
-        securityContext:
-          privileged: true
+{{ include "init-containers" .Values.common | indent 6}}
       containers:
       - name: elasticsearch
         securityContext:
@@ -84,7 +81,7 @@ spec:
         - name: NODE_INGEST
           value: "false"
         - name: HTTP_ENABLE
-          value: "{{ .Values.data.enableHTTP }}"
+          value: "{{ .Values.master.enableHTTP }}"
         - name: PROCESSORS
           value: "{{ .Values.master.processors }}"
         {{- range $key, $value :=  .Values.common.env }}
@@ -99,7 +96,7 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
-        {{- if .Values.data.enableHTTP }}
+        {{- if .Values.master.enableHTTP }}
         - containerPort: 9200
           name: http
           protocol: TCP
@@ -121,12 +118,26 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
         volumeMounts:
-        - mountPath: /data
+        - mountPath: /usr/share/elasticsearch/config/
+          name: configdir
+        - mountPath: /usr/share/elasticsearch/plugins/
+          name: plugindir
+        - mountPath: /storage/
           name: storage
-        - mountPath: /elasticsearch/config/elasticsearch.yml
+        - mountPath: /usr/share/elasticsearch/config/jvm.settings
+          name: config
+          subPath: jvm.settings
+        - mountPath: /usr/share/elasticsearch/config/log4j2.properties
+          name: config
+          subPath: log4j2.properties
+        - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
       volumes:
+        - name: configdir
+          emptyDir: {}
+        - name: plugindir
+          emptyDir: {}
         - configMap:
             name: {{ template "fullname" . }}-config
           name: config

--- a/values.yaml
+++ b/values.yaml
@@ -1,14 +1,18 @@
 common:
   image:
-    repository: quay.io/pires/docker-elasticsearch-kubernetes
-    tag: 5.6.3
-    pullPolicy: Always
+    repository: blacktop/elasticsearch
+    tag: "6.0"
+    pullPolicy: IfNotPresent
 
   # Defines the service type for all outward-facing (non-discovery) services.
   serviceType: ClusterIP
   # Any extra or specific configuration that is needed can be added here.
   config:
     index.codec: best_compression
+  # If you want any plugins installed, give them here as a list. They will be
+  # passed to elasticsearch-plugin install {line here}
+  plugins:
+  # - ingest-geoip
 
   env:
     CLUSTER_NAME: "elasticsearch"


### PR DESCRIPTION
This addresses a couple of issues:
 - Big plugin installs will not get killed by failing the readinessProbe timeout
 - No need for a custom image or script to install plugins through env variable
 - All three config files are now in the config map

Fixes #5