### PR TITLE
Add in Searchguard support for Elasticsearch

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,8 +37,8 @@ init container template
     privileged: true
 {{- if $.Values.tls.enable }}
 - name: generate-tls-pair
-  image: "{{ .Values.tls.image }}:{{ .Values.tls.tag }}"
-  imagePullPolicy: {{ .Values.tls.pullPolicy }}
+  image: "{{ .Values.tls.image }}:{{ .Values.tls.imageTag }}"
+  imagePullPolicy: {{ .Values.tls.imagePullPolicy }}
   env:
   - name: NAMESPACE
     valueFrom:
@@ -88,7 +88,7 @@ init container template
   command:
     - "sh"
     - "-c"
-    - "{{- range .Values.common.plugins }}elasticsearch-plugin install {{ . }};{{- end }} chown -R elasticsearch: /usr/share/elasticsearch/ /storage/; true"
+    - "{{ if .Values.searchguard.enable }}elasticsearch-plugin install {{ .Values.searchguard.plugin }};{{ end }}{{- range .Values.common.plugins }}elasticsearch-plugin install {{ . }};{{- end }} true"
   env:
   - name: NODE_NAME
     value: es-plugin-install
@@ -102,5 +102,13 @@ init container template
   - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
     name: config
     subPath: elasticsearch.yml
+  - mountPath: /usr/share/elasticsearch/config/tls/
+    name: tls
 {{- end }}
+- name: permissions
+  image: busybox
+  command: ["sh", "-c", "chmod 400 /usr/share/elasticsearch/config/tls/*; chown -R 1000: /usr/share/elasticsearch/ /storage/; true"]
+  volumeMounts:
+  - mountPath: /storage
+    name: storage
 {{- end -}}

--- a/templates/client-deployment.yaml
+++ b/templates/client-deployment.yaml
@@ -104,11 +104,16 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
         readinessProbe:
+        {{- if .Values.searchguard.enable }}
+          tcpSocket:
+            port: http
+        {{- else }}
           httpGet:
             path: /_cluster/health
             port: http
-        {{- if .Values.tls.enable }}
+            {{- if .Values.tls.enable }}
             scheme: HTTPS
+            {{- end }}
         {{- end }}
           initialDelaySeconds: 20
           timeoutSeconds: 5
@@ -136,6 +141,10 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
+        {{- if .Values.searchguard.enable }}
+        - mountPath: /usr/share/elasticsearch/plugins/search-guard-6/sgconfig/
+          name: searchguard-config
+        {{- end }}
       volumes:
         {{- if .Values.common.plugins }}
         - name: configdir
@@ -153,3 +162,8 @@ spec:
         - emptyDir:
             medium: ""
           name: storage
+        {{- if .Values.searchguard.enable }}
+        - configMap:
+            name: {{ template "fullname" . }}-searchguard-config
+          name: searchguard-config
+        {{- end }}

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - delete
+{{- end -}}

--- a/templates/clusterrolebinding.yaml
+++ b/templates/clusterrolebinding.yaml
@@ -1,21 +1,19 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
+kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "fullname" .}}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
-rules:
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  verbs:
-  - create
-  - get
-  - delete
 {{- end -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -71,10 +71,19 @@ data:
     processors: ${PROCESSORS:}
     {{- if .Values.tls.enable }}
     searchguard:
-      #  nodes_dn:
-      #    - "CN=*.{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}"
+      {{- if .Values.searchguard.enable }}
+      enterprise_modules_enabled: {{ .Values.searchguard.enterprise_modules }}
+      restapi:
+        roles_enabled: ["sg_all_access"]
+      nodes_dn:
+        - "CN=*.{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}"
+      authcz:
+        admin_dn:
+          - "CN=admin.{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }},OU=sgadmin,O=logging"
+      {{- end }}
       ssl:
         http:
+          clientauth_mode: REQUIRE
           enabled: true
           enabled_protocols:
           - "TLSv1.2"

--- a/templates/curator-clusterrole.yaml
+++ b/templates/curator-clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-curator
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+      - delete
+{{- end -}}

--- a/templates/curator-clusterrolebinding.yaml
+++ b/templates/curator-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.curator.enable -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "fullname" .}}
+    component: curator
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-curator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}-curator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}-curator
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/templates/curator-configmap.yaml
+++ b/templates/curator-configmap.yaml
@@ -1,9 +1,10 @@
-{{- if .Values.curator.enabled }}
+{{- if .Values.curator.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-curator-config
   labels:
+    component: curator
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -43,21 +44,29 @@ data:
     # not a Python "NoneType"
     client:
       hosts:
-        - {{ template "fullname" . }}
+        - {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}
       port: {{ .Values.service.httpPort }}
       url_prefix:
+      {{- if .Values.tls.enable }}
+      use_ssl: True
+      certificate: /tls/ca.crt
+      client_cert: /tls/tls.crt
+      client_key: /tls/tls.key
+      ssl_no_validate: False
+      {{- else }}
       use_ssl: False
       certificate:
       client_cert:
       client_key:
       ssl_no_validate: False
+      {{- end }}
       http_auth:
       timeout: 30
       master_only: False
 
     logging:
-      loglevel: INFO
+      loglevel: DEBUG
       logfile:
-      logformat: default
-      blacklist: ['elasticsearch', 'urllib3']
+      logformat: json
+      blacklist: [] #['elasticsearch', 'urllib3']
 {{- end }}

--- a/templates/curator-cronjob.yaml
+++ b/templates/curator-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.curator.enabled }}
+{{- if .Values.curator.enable }}
 apiVersion: {{ template "curator.cronJob.apiVersion" . }}
 kind: CronJob
 metadata:
@@ -14,14 +14,57 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: {{ template "fullname" . }}-curator
+          subdomain: "{{ template "fullname" . }}"
+          {{- if .Values.tls.enable }}
+          initContainers:
+            - name: generate-tls-pair
+              image: "{{ .Values.tls.image }}:{{ .Values.tls.imageTag }}"
+              imagePullPolicy: "{{ .Values.tls.imagePullPolicy }}"
+              env:
+              - name: NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: SUBDOMAIN
+                value: {{ template "fullname" . }}
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              args:
+              - "-namespace=$(NAMESPACE)"
+              - "-pod-ip=$(POD_IP)"
+              - "-pod-name=$(POD_NAME)"
+              - "-hostname=$(POD_NAME)"
+              - "-subdomain=$(SUBDOMAIN)"
+              - "-organizations=logging"
+              - "-organizational-units=curator"
+              - "-headless-name-as-cn"
+              - "-service-names={{ template "fullname" . }}-discovery,{{ template "fullname" . }}"
+              - "-pkcs8"
+              - "-labels=component={{ template "fullname" . }}"
+              - "-secret-name={{ template "fullname" . }}-curator-keys"
+          {{- end }}
           containers:
-          - name: curator
-            image: quay.io/lalamove/elasticsearch-curator:5.4.0
-            args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
-            volumeMounts:
-              - name: config-volume
-                mountPath: /etc/config
+            - name: curator
+              image: "{{ .Values.curator.image }}:{{ .Values.curator.imageTag }}"
+              imagePullPolicy: "{{ .Values.curator.imagePullPolicy }}"
+              args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/config
+                - name: tls
+                  mountPath: /tls
           volumes:
+            - name: tls
+              secret:
+                secretName: {{ template "fullname" . }}-curator-keys
+                defaultMode: 511
             - name: config-volume
               configMap:
                 name: {{ template "fullname" . }}-curator-config

--- a/templates/curator-role.yaml
+++ b/templates/curator-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-curator
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - "{{ template "fullname" . }}-curator-keys"
+    verbs:
+      - update
+      - get
+{{- end -}}

--- a/templates/curator-rolebinding.yaml
+++ b/templates/curator-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.curator.enable -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "fullname" .}}
+    component: curator
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-curator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fullname" . }}-curator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}-curator
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/templates/curator-secret.yaml
+++ b/templates/curator-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.curator.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: curator
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}-curator-keys
+  namespace: {{ .Release.Namespace }}
+type: tls
+data:
+{{- end }}

--- a/templates/curator-serviceaccount.yaml
+++ b/templates/curator-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.curator.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: curator
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-curator
+{{- end }}

--- a/templates/data-statefulset.yaml
+++ b/templates/data-statefulset.yaml
@@ -101,18 +101,20 @@ spec:
         - containerPort: 9200
           name: http
           protocol: TCP
+        {{- end }}
         readinessProbe:
+          {{- if and .Values.master.enableHTTP (not .Values.searchguard.enable) }}
+          {{/* We cannot use http readinessProbe for searchguard since it requires client cert auth */}}
           httpGet:
             path: /_cluster/health?local=true
             port: http
-        {{- if .Values.tls.enable }}
+            {{- if .Values.tls.enable }}
             scheme: HTTPS
-        {{- end }}
-        {{- else }}
-        readinessProbe:
+            {{- end }}
+          {{- else }}
           tcpSocket:
             port: transport
-        {{- end }}
+          {{- end }}
           initialDelaySeconds: 20
           periodSeconds: 5
           failureThreshold: 20
@@ -144,6 +146,10 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
+        {{- if .Values.searchguard.enable }}
+        - mountPath: /usr/share/elasticsearch/plugins/search-guard-6/sgconfig/
+          name: searchguard-config
+        {{- end }}
       volumes:
         {{- if .Values.common.plugins }}
         - name: configdir
@@ -158,6 +164,11 @@ spec:
         - configMap:
             name: {{ template "fullname" . }}-config
           name: config
+        {{- if .Values.searchguard.enable }}
+        - configMap:
+            name: {{ template "fullname" . }}-searchguard-config
+          name: searchguard-config
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: storage

--- a/templates/master-statefulset.yaml
+++ b/templates/master-statefulset.yaml
@@ -101,18 +101,20 @@ spec:
         - containerPort: 9200
           name: http
           protocol: TCP
+        {{- end }}
         readinessProbe:
+          {{- if and .Values.master.enableHTTP (not .Values.searchguard.enable) -}}
+          {{/* We cannot use http readinessProbe for searchguard since it requires client cert auth */}}
           httpGet:
             path: /_cluster/health?local=true
             port: http
-        {{- if .Values.tls.enable }}
+            {{- if .Values.tls.enable }}
             scheme: HTTPS
-        {{- end }}
-        {{- else }}
-        readinessProbe:
+            {{- end }}
+          {{- else }}
           tcpSocket:
             port: transport
-        {{- end }}
+          {{- end }}
           initialDelaySeconds: 20
           periodSeconds: 5
           failureThreshold: 20
@@ -144,6 +146,10 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
+        {{- if .Values.searchguard.enable }}
+        - mountPath: /usr/share/elasticsearch/plugins/search-guard-6/sgconfig/
+          name: searchguard-config
+        {{- end }}
       volumes:
         {{- if .Values.common.plugins }}
         - name: configdir
@@ -158,6 +164,11 @@ spec:
         - configMap:
             name: {{ template "fullname" . }}-config
           name: config
+        {{- if .Values.searchguard.enable }}
+        - configMap:
+            name: {{ template "fullname" . }}-searchguard-config
+          name: searchguard-config
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: storage

--- a/templates/searchguard-configmap.yaml
+++ b/templates/searchguard-configmap.yaml
@@ -1,0 +1,332 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-searchguard-config
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  sg_action_groups.yml: |-
+    UNLIMITED:
+      readonly: true
+      permissions:
+        - "*"
+    INDICES_ALL:
+      readonly: true
+      permissions:
+        - "indices:*"
+    MANAGE:
+      readonly: true
+      permissions:
+        - "indices:monitor/*"
+        - "indices:admin/*"
+    CREATE_INDEX:
+      readonly: true
+      permissions:
+        - "indices:admin/create"
+        - "indices:admin/mapping/put"
+    MANAGE_ALIASES:
+      readonly: true
+      permissions:
+        - "indices:admin/aliases*"
+    INDICES_MONITOR:
+      readonly: true
+      permissions:
+        - "indices:monitor/*"
+    DATA_ACCESS:
+      readonly: true
+      permissions:
+        - "indices:data/*"
+        - CRUD
+    WRITE:
+      readonly: true
+      permissions:
+        - "indices:data/write*"
+        - "indices:admin/mapping/put"
+    READ:
+      readonly: true
+      permissions:
+        - "indices:data/read*"
+        - "indices:admin/mappings/fields/get*"
+    DELETE:
+      readonly: true
+      permissions:
+        - "indices:data/write/delete*"
+    CRUD:
+      readonly: true
+      permissions:
+        - READ
+        - WRITE
+    SEARCH:
+      readonly: true
+      permissions:
+        - "indices:data/read/search*"
+        - "indices:data/read/msearch*"
+        - SUGGEST
+    SUGGEST:
+      readonly: true
+      permissions:
+        - "indices:data/read/suggest*"
+    INDEX:
+      readonly: true
+      permissions:
+        - "indices:data/write/index*"
+        - "indices:data/write/update*"
+        - "indices:admin/mapping/put"
+        - "indices:data/write/bulk*"
+    GET:
+      readonly: true
+      permissions:
+        - "indices:data/read/get*"
+        - "indices:data/read/mget*"
+
+    CLUSTER_ALL:
+      readonly: true
+      permissions:
+        - "cluster:*"
+    CLUSTER_MONITOR:
+      readonly: true
+      permissions:
+        - "cluster:monitor/*"
+    CLUSTER_COMPOSITE_OPS_RO:
+      readonly: true
+      permissions:
+        - "indices:data/read/mget"
+        - "indices:data/read/msearch"
+        - "indices:data/read/mtv"
+        - "indices:data/read/coordinate-msearch*"
+        - "indices:admin/aliases/exists*"
+        - "indices:admin/aliases/get*"
+        - "indices:data/read/scroll"
+    CLUSTER_COMPOSITE_OPS:
+      readonly: true
+      permissions:
+        - "indices:data/write/bulk"
+        - "indices:admin/aliases*"
+        - CLUSTER_COMPOSITE_OPS_RO
+    MANAGE_SNAPSHOTS:
+      readonly: true
+      permissions:
+        - "cluster:admin/snapshot/*"
+        - "cluster:admin/repository/*"
+  sg_config.yml: |-
+    searchguard:
+      dynamic:
+        kibana:
+          multitenancy_enabled: false
+          server_username: {{ .Values.searchguard.kibana_user }}
+          index: '.kibana'
+          do_not_fail_on_forbidden: false
+        http:
+          anonymous_auth_enabled: false
+          xff:
+            enabled: true
+            internalProxies: '.+' # since we require clientauth cert for http, we do not need to do IP filtering
+            remoteIpHeader:  'x-forwarded-for'
+            proxiesHeader:   'x-forwarded-by'
+            trustedProxies: '.+' # trust all external proxies, regex pattern
+        authc:
+          proxy_auth_domain:
+            http_enabled: true
+            transport_enabled: false
+            order: 0
+            http_authenticator:
+              type: proxy
+              challenge: false
+              config:
+                user_header: "x-forwarded-email"
+                #roles_header: "x-proxy-roles"
+            authentication_backend:
+              type: noop
+          clientcert_auth_domain:
+            http_enabled: true
+            transport_enabled: true
+            order: 1
+            http_authenticator:
+              type: clientcert
+              config:
+                username_attribute: ou #optional, if omitted DN becomes username
+              challenge: false
+            authentication_backend:
+              type: noop
+  sg_roles.yml: |-
+    # Allows everything, but no changes to searchguard configuration index
+    sg_all_access:
+      readonly: true
+      cluster:
+        - UNLIMITED
+      indices:
+        '*':
+          '*':
+            - UNLIMITED
+      tenants:
+        admin_tenant: RW
+
+    # Read all, but no write permissions
+    sg_readall:
+      readonly: true
+      cluster:
+        - CLUSTER_COMPOSITE_OPS_RO
+      indices:
+        '*':
+          '*':
+            - READ
+
+    # Read all and monitor, but no write permissions
+    sg_readall_and_monitor:
+      cluster:
+        - CLUSTER_MONITOR
+        - CLUSTER_COMPOSITE_OPS_RO
+      indices:
+        '*':
+          '*':
+            - READ
+
+    # For users which use kibana, access to indices must be granted separately
+    sg_kibana_user:
+      readonly: true
+      cluster:
+        - MONITOR
+        - CLUSTER_COMPOSITE_OPS_RO
+      indices:
+        '?kibana':
+          '*':
+            - MANAGE
+            - INDEX
+            - READ
+            - DELETE
+        '*':
+          '*':
+            - "indices:data/read/field_caps"
+
+    # For the kibana server
+    sg_kibana_server:
+      readonly: true
+      cluster:
+        - CLUSTER_MONITOR
+        - CLUSTER_COMPOSITE_OPS
+        - "indices:admin/template/put"
+      indices:
+        'logstash-*':
+          '*':
+            - "indices:data/read/field_caps*"
+        '?kibana':
+          '*':
+            - INDICES_ALL
+        '?reporting*':
+          '*':
+            - INDICES_ALL
+        '?monitoring*':
+          '*':
+            - INDICES_ALL
+
+    sg_logreader:
+      readonly: true
+      indices:
+        'logstash-*':
+          '*':
+            - READ
+
+    # For logstash and beats
+    sg_logwrite:
+      readonly: true
+      cluster:
+        - CLUSTER_MONITOR
+        - CLUSTER_COMPOSITE_OPS
+        - "indices:admin/template/get"
+        - "indices:admin/template/put"
+      indices:
+        'logstash-*':
+          '*':
+            - WRITE
+            - CREATE_INDEX
+        '*beat*':
+          '*':
+            - WRITE
+            - CREATE_INDEX
+
+    sg_prometheus:
+      readonly: true
+      cluster:
+        - CLUSTER_MONITOR
+        - INDICES_MONITOR
+
+    sg_curator:
+      readonly: true
+      cluster:
+        - CLUSTER_MONITOR
+        - CLUSTER_COMPOSITE_OPS
+      indicies:
+        'logstash-*':
+          '*':
+            - INDICES_MONITOR
+            - DELETE
+
+    # Allows adding and modifying repositories and creating and restoring snapshots
+    sg_manage_snapshots:
+      readonly: true
+      cluster:
+        - MANAGE_SNAPSHOTS
+      indices:
+        '*':
+          '*':
+            - "indices:data/write/index"
+            - "indices:admin/create"
+
+    # Allows each user to access own named index
+    sg_own_index:
+      cluster:
+        - CLUSTER_COMPOSITE_OPS
+      indices:
+        '${user_name}':
+          '*':
+            - INDICES_ALL
+
+  sg_roles_mapping.yml: |-
+    sg_curator:
+      readonly: true
+      users:
+        - curator
+    sg_prometheus:
+      readonly: true
+      users:
+        - prometheus
+    sg_all_access:
+      readonly: true
+      users:
+{{ toYaml .Values.searchguard.admins | indent 8 }}
+      backendroles:
+        - admin
+    sg_logwrite:
+      users:
+        - logwrite
+    sg_kibana_server:
+      readonly: true
+      users:
+        - kibana
+    sg_kibana_user:
+      users:
+{{ toYaml .Values.searchguard.users | indent 8 }}
+    sg_logreader:
+      users:
+{{ toYaml .Values.searchguard.users | indent 8 }}
+      backendroles:
+        - kibanauser
+    sg_readall:
+      readonly: true
+      backendroles:
+        - readall
+    sg_manage_snapshots:
+      readonly: true
+      backendroles:
+        - snapshotrestore
+    sg_own_index:
+      users:
+        - '*'
+
+  sg_internal_users.yml: |-
+    # This is the internal user database
+    # The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+    {}

--- a/templates/sginit-clusterrole.yaml
+++ b/templates/sginit-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: sginit
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-sginit
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+      - delete
+{{- end -}}

--- a/templates/sginit-clusterrolebinding.yaml
+++ b/templates/sginit-clusterrolebinding.yaml
@@ -1,20 +1,20 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.searchguard.enable -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ template "fullname" .}}
+    component: sginit
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "fullname" . }}-sginit
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-sginit
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-sginit
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/templates/sginit-job.yaml
+++ b/templates/sginit-job.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.searchguard.enable }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-sginit
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  activeDeadlineSeconds: {{ default 600 .Values.searchguard.init.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      serviceAccountName: "{{ template "fullname" . }}-sginit"
+      subdomain: "{{ template "fullname" . }}"
+      initContainers:
+        - name: generate-tls-pair
+          image: "{{ .Values.tls.image }}:{{ .Values.tls.imageTag }}"
+          imagePullPolicy: {{ .Values.tls.imagePullPolicy }}
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: SUBDOMAIN
+            value: {{ template "fullname" . }}
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          args:
+          - "-namespace=$(NAMESPACE)"
+          - "-pod-ip=$(POD_IP)"
+          - "-pod-name=$(POD_NAME)"
+          - "-hostname=admin"
+          - "-subdomain=$(SUBDOMAIN)"
+          - "-organizational-units=sgadmin"
+          - "-organizations=logging"
+          - "-headless-name-as-cn"
+          - "-pkcs8"
+          - "-labels=component={{ template "fullname" . }}"
+          - "-secret-name={{ template "fullname" . }}-sg-admin-credentials"
+        - name: wait-for-es
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sh"
+            - "-c"
+            - "until nc -w 1 -z {{ template "fullname" . }} 9300; do echo waiting for elasticsearch to come up; sleep 2; done"
+      containers:
+      - name: sginit
+        image: "{{ .Values.searchguard.init.image }}:{{ .Values.searchguard.init.imageTag }}"
+        args:
+          - "--configdir"
+          - "/sgconfig/"
+          - "-cacert"
+          - "/tls/ca.crt"
+          - "--clustername"
+          - "{{ .Values.common.env.CLUSTER_NAME }}"
+          - "--hostname"
+          - "{{ template "fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}"
+          - "-cert"
+          - "/tls/tls.crt"
+          - "-key"
+          - "/tls/tls.key"
+        volumeMounts:
+          - name: tls
+            mountPath: /tls
+          - name: searchguard-config
+            mountPath: /sgconfig
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ template "fullname" . }}-sg-admin-credentials
+            defaultMode: 0400
+        - name: searchguard-config
+          configMap:
+            name: {{ template "fullname" . }}-searchguard-config
+      restartPolicy: {{ .Values.searchguard.init.restartPolicy }}
+{{- end }}

--- a/templates/sginit-role.yaml
+++ b/templates/sginit-role.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: sginit
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-sginit
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
+    resourceNames:
+      - "{{ template "fullname" . }}-sg-admin-credentials"
+    verbs:
+      - update
+      - get
+{{- end -}}

--- a/templates/sginit-rolebinding.yaml
+++ b/templates/sginit-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.searchguard.enable -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "fullname" .}}
+    component: sginit
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-sginit
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fullname" . }}-sginit
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}-sginit
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/templates/sginit-secret.yaml
+++ b/templates/sginit-secret.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.searchguard.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: sginit
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}-sg-admin-credentials
+  namespace: {{ .Release.Namespace }}
+type: tls
+data:
+{{- end }}

--- a/templates/sginit-serviceaccount.yaml
+++ b/templates/sginit-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.searchguard.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    component: sginit
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}-sginit
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -100,8 +100,11 @@ master:
       memory: 256Mi
 
 curator:
-  enabled: true
+  enable: true
   schedule: "0 1 * * *"
+  image: quay.io/lalamove/elasticsearch-curator
+  imageTag: "5.4.0"
+  imagePullPolicy: "IfNotPresent"
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in
   # templates/es-curator-config.yaml.
@@ -121,5 +124,19 @@ tls:
   enable: false
   clusterDomain: cluster.local
   image: quay.io/lalamove/certificate-init-container
-  tag: v0.0.4
-  pullPolicy: "IfNotPresent"
+  imageTag: v0.2.0
+  imagePullPolicy: "IfNotPresent"
+
+searchguard:
+  enable: false
+  plugin: com.floragunn:search-guard-6:6.1.0-20.0
+  enterprise_modules: false
+  kibana_user: kibana
+  admins:
+  users:
+  init:
+    image: quay.io/lalamove/sgadmin
+    imageTag: v6.1.0-20.0
+    imagePullPolicy: "IfNotPresent"
+    restartPolicy: Never
+    activeDeadlineSeconds: 600


### PR DESCRIPTION
This fixes #11 and also includes a fix for #22.
This addresses several issues with the helm chart, including:
 - Permissions for /storage not always changed
 - Permissions for Kubernetes API too permissive

And adds in support for Searchguard as the TLS and RBAC provider