### PR TITLE
Fix for issue #28

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -16,7 +16,7 @@ We truncate at 53 chars (63 - len("-discovery")) because some Kubernetes name fi
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for Curactor cron job.
+Return the appropriate apiVersion for the Curator cron job.
 */}}
 {{- define "curator.cronJob.apiVersion" -}}
 {{- if ge .Capabilities.KubeVersion.Minor "8" -}}
@@ -33,6 +33,13 @@ init container template
   image: busybox
   imagePullPolicy: IfNotPresent
   command: ["sysctl", "-w", "vm.max_map_count=262144"]
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   securityContext:
     privileged: true
 {{- if $.Values.tls.enable }}
@@ -72,6 +79,13 @@ init container template
   image: busybox
   imagePullPolicy: IfNotPresent
   command: ["cp", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", "/tls/ca.crt"]
+  resources:
+      limits:
+        cpu: "500m"
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
   volumeMounts:
     - name: tls
       mountPath: /tls
@@ -85,6 +99,13 @@ init container template
       add:
         - IPC_LOCK
         - SYS_RESOURCE
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   command:
     - "sh"
     - "-c"
@@ -92,6 +113,13 @@ init container template
   env:
   - name: NODE_NAME
     value: es-plugin-install
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   volumeMounts:
   - mountPath: /storage/
     name: storage
@@ -108,6 +136,13 @@ init container template
 - name: permissions
   image: busybox
   command: ["sh", "-c", "chmod 400 /usr/share/elasticsearch/config/tls/*; chown -R 1000: /usr/share/elasticsearch/ /storage/; true"]
+  resources:
+    limits:
+      cpu: "500m"
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
   volumeMounts:
   - mountPath: /storage
     name: storage

--- a/templates/client-deployment.yaml
+++ b/templates/client-deployment.yaml
@@ -49,8 +49,6 @@ spec:
                   component: {{ template "fullname" . }}
                   role: client
       {{- end }}
-      resources:
-{{ toYaml .Values.client.resources | indent 6 }}
       initContainers:
 {{ include "init-containers" . | indent 6 }}
       containers:
@@ -93,6 +91,8 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+{{ toYaml .Values.client.resources | indent 10 }}
         ports:
         - containerPort: 9200
           name: http

--- a/templates/curator-cronjob.yaml
+++ b/templates/curator-cronjob.yaml
@@ -55,6 +55,13 @@ spec:
               image: "{{ .Values.curator.image }}:{{ .Values.curator.imageTag }}"
               imagePullPolicy: "{{ .Values.curator.imagePullPolicy }}"
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
               volumeMounts:
                 - name: config-volume
                   mountPath: /etc/config

--- a/templates/data-statefulset.yaml
+++ b/templates/data-statefulset.yaml
@@ -51,8 +51,6 @@ spec:
                   component: {{ template "fullname" . }}
                   role: data
       {{- end }}
-      resources:
-{{ toYaml .Values.data.resources | indent 6 }}
       initContainers:
 {{ include "init-containers" . | indent 6 }}
       containers:
@@ -95,6 +93,8 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+{{ toYaml .Values.data.resources | indent 10 }}
         ports:
         - containerPort: 9300
           name: transport

--- a/templates/master-statefulset.yaml
+++ b/templates/master-statefulset.yaml
@@ -51,8 +51,6 @@ spec:
                   component: {{ template "fullname" . }}
                   role: master
       {{- end }}
-      resources:
-{{ toYaml .Values.master.resources | indent 6 }}
       initContainers:
 {{ include "init-containers" . | indent 6 }}
       containers:
@@ -95,6 +93,8 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+{{ toYaml .Values.master.resources | indent 10 }}
         ports:
         - containerPort: 9300
           name: transport


### PR DESCRIPTION
Resource blocks have been moved to correct location for master, data and client charts.

Resource blocks have been added to init-container sections and curator chart. This enables the chart to be deployed to a namespace with resources quotas.